### PR TITLE
Fix for issue #2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ var transormToDotNotation = function (node) {
         }),
         endToken: old.endToken
     };
+    block.endToken.type = 'Identifier';
+    block.startToken.next.type = 'Identifier';
     old.parent = block;
     node = block;
 };

--- a/tests/compare.spec.js
+++ b/tests/compare.spec.js
@@ -58,9 +58,8 @@ describe('esformatter-dot-notation', function () {
         });
     });
 
-    xdescribe('integration with esformatter-quotes', function () {
+    describe('integration with esformatter-quotes', function () {
         it('should correctly transform string', function () {
-            esformatter.unregister(dotNotation);
             // register plugin
             esformatter.register(require('esformatter-quotes'));
             //jshint quotmark:false


### PR DESCRIPTION
Some tokens were still of type `String` (instead of `Identifier`) which caused esformatter-quotes to react.
